### PR TITLE
Fetch Twitter user followings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Twitter API 配置
+# 从 https://api.twitterapi.io/ 获取您的API密钥
+TWITTER_API_KEY=your_api_key_here

--- a/examples/get_followings_example.py
+++ b/examples/get_followings_example.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""获取用户关注列表的示例"""
+
+import sys
+import os
+
+# 添加项目路径以便导入模块
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from follow_elon.api import TwitterAPIClient
+
+
+def main():
+    """主函数"""
+    try:
+        # 初始化客户端，使用x-api-key认证方式（默认）
+        client = TwitterAPIClient(auth_type="x-api-key")
+        
+        # 获取用户关注列表
+        username = "KaitoEasyAPI"  # 您curl示例中使用的用户名
+        print(f"正在获取 @{username} 的关注列表...")
+        
+        # 获取关注列表
+        followings = client.get_user_followings(username, count=10)
+        print(f"成功获取关注列表:")
+        print(f"数据类型: {type(followings)}")
+        
+        # 如果返回的是字典且包含数据
+        if isinstance(followings, dict):
+            if "data" in followings:
+                users = followings["data"]
+                print(f"找到 {len(users)} 个关注的用户")
+                for i, user in enumerate(users[:5], 1):
+                    username = user.get('username', user.get('screen_name', '未知'))
+                    name = user.get('name', user.get('display_name', '未知'))
+                    print(f"{i}. @{username} ({name})")
+            else:
+                print(f"响应数据: {followings}")
+        elif isinstance(followings, list):
+            print(f"找到 {len(followings)} 个关注的用户")
+            for i, user in enumerate(followings[:5], 1):
+                username = user.get('username', user.get('screen_name', '未知'))
+                name = user.get('name', user.get('display_name', '未知'))
+                print(f"{i}. @{username} ({name})")
+        else:
+            print(f"未预期的数据格式: {followings}")
+        
+        # 也可以获取粉丝列表
+        print(f"\n正在获取 @{username} 的粉丝列表...")
+        followers = client.get_user_followers(username, count=5)
+        print(f"粉丝数据类型: {type(followers)}")
+        
+        # 关闭客户端
+        client.close()
+        
+    except Exception as e:
+        print(f"发生错误: {e}")
+        print(f"错误类型: {type(e).__name__}")
+        if hasattr(e, 'status_code'):
+            print(f"HTTP状态码: {e.status_code}")
+        if hasattr(e, 'response_data'):
+            print(f"响应数据: {e.response_data}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,10 @@
 [project]
 name = "follow-elon"
 version = "0.1.0"
-description = "Add your description here"
+description = "Twitter API client for following Elon and other users"
 readme = "README.md"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = [
+    "requests>=2.31.0",
+    "python-dotenv>=1.0.0",
+]

--- a/src/follow_elon/__init__.py
+++ b/src/follow_elon/__init__.py
@@ -1,0 +1,2 @@
+"""follow-elon package"""
+__version__ = "0.1.0"

--- a/src/follow_elon/api/__init__.py
+++ b/src/follow_elon/api/__init__.py
@@ -1,0 +1,19 @@
+"""Twitter API模块"""
+
+from .client import TwitterAPIClient
+from .exceptions import (
+    TwitterAPIError,
+    AuthenticationError, 
+    RateLimitError,
+    NotFoundError,
+    ValidationError,
+)
+
+__all__ = [
+    "TwitterAPIClient",
+    "TwitterAPIError",
+    "AuthenticationError",
+    "RateLimitError", 
+    "NotFoundError",
+    "ValidationError",
+]

--- a/src/follow_elon/api/client.py
+++ b/src/follow_elon/api/client.py
@@ -1,0 +1,360 @@
+"""Twitter API客户端"""
+
+import os
+import time
+from typing import Dict, List, Optional, Any
+from urllib.parse import urljoin
+import requests
+from dotenv import load_dotenv
+
+from .exceptions import (
+    TwitterAPIError,
+    AuthenticationError,
+    RateLimitError,
+    NotFoundError,
+    ValidationError,
+)
+
+# 加载环境变量
+load_dotenv()
+
+
+class TwitterAPIClient:
+    """Twitter API通用客户端类"""
+
+    def __init__(self, api_key: str = None, base_url: str = None, auth_type: str = "x-api-key"):
+        """
+        初始化Twitter API客户端
+
+        Args:
+            api_key: API密钥，如果不提供则从环境变量TWITTER_API_KEY获取
+            base_url: API基础URL，默认使用twitterapi.io
+            auth_type: 认证类型，可选值: "x-api-key" 或 "bearer"
+        """
+        self.api_key = api_key or os.getenv("TWITTER_API_KEY")
+        self.base_url = base_url or "https://api.twitterapi.io/"
+        self.auth_type = auth_type
+
+        if not self.api_key:
+            raise AuthenticationError(
+                "API密钥未提供，请设置TWITTER_API_KEY环境变量或传入api_key参数"
+            )
+
+        self.session = requests.Session()
+        
+        # 根据认证类型设置不同的头部
+        if self.auth_type == "x-api-key":
+            self.session.headers.update(
+                {
+                    "x-api-key": self.api_key,
+                    "Content-Type": "application/json",
+                    "User-Agent": "follow-elon/0.1.0",
+                }
+            )
+        elif self.auth_type == "bearer":
+            self.session.headers.update(
+                {
+                    "Authorization": f"Bearer {self.api_key}",
+                    "Content-Type": "application/json",
+                    "User-Agent": "follow-elon/0.1.0",
+                }
+            )
+        else:
+            raise ValidationError("auth_type必须是 'x-api-key' 或 'bearer' 之一")
+
+    def _make_request(
+        self, method: str, endpoint: str, params: Dict = None, data: Dict = None
+    ) -> Dict:
+        """
+        发送HTTP请求的通用方法
+
+        Args:
+            method: HTTP方法 (GET, POST, PUT, DELETE)
+            endpoint: API端点
+            params: URL参数
+            data: 请求体数据
+
+        Returns:
+            API响应数据
+
+        Raises:
+            TwitterAPIError: API请求失败时抛出相应异常
+        """
+        url = urljoin(self.base_url, endpoint.lstrip("/"))
+
+        try:
+            response = self.session.request(
+                method=method.upper(), url=url, params=params, json=data, timeout=30
+            )
+
+            # 处理不同的HTTP状态码
+            if response.status_code == 200:
+                return response.json()
+            elif response.status_code == 401:
+                raise AuthenticationError(
+                    "认证失败，请检查API密钥", response.status_code, response.json()
+                )
+            elif response.status_code == 404:
+                raise NotFoundError("资源未找到", response.status_code, response.json())
+            elif response.status_code == 429:
+                # 处理速率限制
+                reset_time = response.headers.get("X-RateLimit-Reset")
+                reset_time = int(reset_time) if reset_time else None
+                raise RateLimitError(
+                    "API速率限制已达到",
+                    status_code=response.status_code,
+                    response_data=response.json(),
+                    reset_time=reset_time,
+                )
+            elif response.status_code == 400:
+                raise ValidationError(
+                    "请求参数错误", response.status_code, response.json()
+                )
+            else:
+                raise TwitterAPIError(
+                    f"API请求失败: {response.status_code}",
+                    response.status_code,
+                    response.json(),
+                )
+
+        except requests.exceptions.Timeout:
+            raise TwitterAPIError("请求超时")
+        except requests.exceptions.ConnectionError:
+            raise TwitterAPIError("网络连接错误")
+        except requests.exceptions.RequestException as e:
+            raise TwitterAPIError(f"请求异常: {str(e)}")
+
+    def get_user_followings(self, username: str, count: int = 20) -> Dict:
+        """
+        获取用户关注列表
+
+        Args:
+            username: 用户名（不包含@符号）
+            count: 返回用户数量，默认20
+
+        Returns:
+            包含关注用户数据的字典
+
+        Raises:
+            ValidationError: 参数验证失败
+            TwitterAPIError: API请求失败
+        """
+        if not username:
+            raise ValidationError("用户名不能为空")
+
+        if not isinstance(count, int) or count < 1:
+            raise ValidationError("count参数必须是大于0的整数")
+
+        # 移除用户名前的@符号
+        username = username.lstrip("@")
+
+        params = {
+            "userName": username,
+            "count": count,
+        }
+
+        return self._make_request("GET", "/twitter/user/followings", params=params)
+
+    def get_user_followers(self, username: str, count: int = 20) -> Dict:
+        """
+        获取用户粉丝列表
+
+        Args:
+            username: 用户名（不包含@符号）
+            count: 返回用户数量，默认20
+
+        Returns:
+            包含粉丝用户数据的字典
+
+        Raises:
+            ValidationError: 参数验证失败
+            TwitterAPIError: API请求失败
+        """
+        if not username:
+            raise ValidationError("用户名不能为空")
+
+        if not isinstance(count, int) or count < 1:
+            raise ValidationError("count参数必须是大于0的整数")
+
+        # 移除用户名前的@符号
+        username = username.lstrip("@")
+
+        params = {
+            "userName": username,
+            "count": count,
+        }
+
+        return self._make_request("GET", "/twitter/user/followers", params=params)
+
+    def get_user_tweets(
+        self, username: str, count: int = 20, include_replies: bool = False
+    ) -> Dict:
+        """
+        获取用户推文
+
+        Args:
+            username: 用户名（不包含@符号）
+            count: 返回推文数量，默认20，最大200
+            include_replies: 是否包含回复，默认False
+
+        Returns:
+            包含推文数据的字典
+
+        Raises:
+            ValidationError: 参数验证失败
+            TwitterAPIError: API请求失败
+        """
+        if not username:
+            raise ValidationError("用户名不能为空")
+
+        if not isinstance(count, int) or count < 1 or count > 200:
+            raise ValidationError("count参数必须是1-200之间的整数")
+
+        # 移除用户名前的@符号
+        username = username.lstrip("@")
+
+        params = {
+            "screen_name": username,
+            "count": count,
+            "include_rts": True,  # 包含转发
+            "exclude_replies": not include_replies,
+            "tweet_mode": "extended",  # 获取完整推文文本
+        }
+
+        return self._make_request("GET", "/statuses/user_timeline", params=params)
+
+    def get_user_replies(self, username: str, count: int = 20) -> Dict:
+        """
+        获取用户回复的推文
+
+        Args:
+            username: 用户名（不包含@符号）
+            count: 返回推文数量，默认20，最大200
+
+        Returns:
+            包含回复推文数据的字典
+        """
+        if not username:
+            raise ValidationError("用户名不能为空")
+
+        if not isinstance(count, int) or count < 1 or count > 200:
+            raise ValidationError("count参数必须是1-200之间的整数")
+
+        username = username.lstrip("@")
+
+        params = {
+            "screen_name": username,
+            "count": count,
+            "include_rts": False,  # 不包含转发
+            "exclude_replies": False,  # 包含回复
+            "tweet_mode": "extended",
+        }
+
+        return self._make_request("GET", "/statuses/user_timeline", params=params)
+
+    def get_user_retweets(self, username: str, count: int = 20) -> Dict:
+        """
+        获取用户转发的推文
+
+        Args:
+            username: 用户名（不包含@符号）
+            count: 返回推文数量，默认20，最大200
+
+        Returns:
+            包含转发推文数据的字典
+        """
+        if not username:
+            raise ValidationError("用户名不能为空")
+
+        if not isinstance(count, int) or count < 1 or count > 200:
+            raise ValidationError("count参数必须是1-200之间的整数")
+
+        username = username.lstrip("@")
+
+        # 首先获取用户的时间线
+        params = {
+            "screen_name": username,
+            "count": count,
+            "include_rts": True,  # 包含转发
+            "exclude_replies": True,  # 排除回复
+            "tweet_mode": "extended",
+        }
+
+        timeline_data = self._make_request(
+            "GET", "/statuses/user_timeline", params=params
+        )
+
+        # 过滤出转发的推文
+        if isinstance(timeline_data, list):
+            retweets = [
+                tweet for tweet in timeline_data if tweet.get("retweeted_status")
+            ]
+            return retweets
+        elif isinstance(timeline_data, dict) and "data" in timeline_data:
+            retweets = [
+                tweet
+                for tweet in timeline_data["data"]
+                if tweet.get("retweeted_status")
+            ]
+            timeline_data["data"] = retweets
+            return timeline_data
+        else:
+            return timeline_data
+
+    def get_user_info(self, username: str) -> Dict:
+        """
+        获取用户信息
+
+        Args:
+            username: 用户名（不包含@符号）
+
+        Returns:
+            用户信息字典
+        """
+        if not username:
+            raise ValidationError("用户名不能为空")
+
+        username = username.lstrip("@")
+
+        params = {"screen_name": username}
+
+        return self._make_request("GET", "/users/show", params=params)
+
+    def search_tweets(
+        self, query: str, count: int = 20, result_type: str = "recent"
+    ) -> Dict:
+        """
+        搜索推文
+
+        Args:
+            query: 搜索查询字符串
+            count: 返回结果数量，默认20，最大100
+            result_type: 结果类型，可选值: 'recent', 'popular', 'mixed'
+
+        Returns:
+            搜索结果字典
+        """
+        if not query:
+            raise ValidationError("搜索查询不能为空")
+
+        if not isinstance(count, int) or count < 1 or count > 100:
+            raise ValidationError("count参数必须是1-100之间的整数")
+
+        if result_type not in ["recent", "popular", "mixed"]:
+            raise ValidationError(
+                "result_type必须是 'recent', 'popular' 或 'mixed' 之一"
+            )
+
+        params = {
+            "q": query,
+            "count": count,
+            "result_type": result_type,
+            "tweet_mode": "extended",
+        }
+
+        return self._make_request("GET", "/search/tweets", params=params)
+
+    def close(self):
+        """关闭会话"""
+        if self.session:
+            self.session.close()

--- a/src/follow_elon/api/exceptions.py
+++ b/src/follow_elon/api/exceptions.py
@@ -1,0 +1,34 @@
+"""Twitter API异常类"""
+
+
+class TwitterAPIError(Exception):
+    """Twitter API基础异常类"""
+
+    def __init__(self, message: str, status_code: int = None, response_data: dict = None):
+        super().__init__(message)
+        self.message = message
+        self.status_code = status_code
+        self.response_data = response_data
+
+
+class AuthenticationError(TwitterAPIError):
+    """认证失败异常"""
+    pass
+
+
+class RateLimitError(TwitterAPIError):
+    """API速率限制异常"""
+
+    def __init__(self, message: str, status_code: int = None, response_data: dict = None, reset_time: int = None):
+        super().__init__(message, status_code, response_data)
+        self.reset_time = reset_time
+
+
+class NotFoundError(TwitterAPIError):
+    """资源未找到异常"""
+    pass
+
+
+class ValidationError(TwitterAPIError):
+    """参数验证异常"""
+    pass


### PR DESCRIPTION
Add a Twitter API client with `x-api-key` authentication and user following/follower methods to support the provided API example.

The user's `curl` example used an `x-api-key` header for authentication and specifically targeted the `/twitter/user/followings` endpoint. This PR introduces a `TwitterAPIClient` that handles this authentication method and provides dedicated methods for fetching user followings and followers, along with other common Twitter API interactions.

---
<a href="https://cursor.com/background-agent?bcId=bc-18f34b26-fd8f-4920-a403-7388836c2f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-18f34b26-fd8f-4920-a403-7388836c2f1b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

